### PR TITLE
Remove other login options but default to E-mail / password #2

### DIFF
--- a/config/@sanity/default-login.json
+++ b/config/@sanity/default-login.json
@@ -1,7 +1,13 @@
 {
   "providers": {
-    "mode": "append",
-    "redirectOnSingle": false,
-    "entries": []
+    "mode": "replace",
+    "redirectOnSingle": true,
+    "entries": [
+      {
+        "name": "sanity",
+        "title": "E-mail / password",
+        "url": "https://api.sanity.io/v1/auth/login/sanity"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Updated the `./config/@sanity/default-login.json` file to automatically redirect to the custom provider login page requiring e-mail and password only.