### PR TITLE
added options to set seoSettings object collapsed by default

### DIFF
--- a/schemas/documents/pages.js
+++ b/schemas/documents/pages.js
@@ -57,7 +57,11 @@ export default {
     {
       title: "SEO Settings",
       name: "seo",
-      type: "seoSettings"
+      type: "seoSettings",
+      options: { 
+        collapsible: true,
+        collapsed: true 
+      }
     }
   ],
 };


### PR DESCRIPTION
Fix for issue: https://github.com/webriq-pagebuilder/site-template-default/issues/5