### PR TITLE
Add plugin media browser to sanity studio

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "sanity-plugin-dashboard-widget-netlify": "^1.1.0",
     "sanity-plugin-google-analytics": "^0.2.6",
     "sanity-plugin-json-input": "^0.1.0",
+    "sanity-plugin-media": "^1.3.1",
     "sanity-plugin-netlify-deploy-status-badge": "^0.0.3",
     "sanity-plugin-parts-list": "^1.0.2",
     "sanity-plugin-seo-pane": "^1.2.1",

--- a/sanity.json
+++ b/sanity.json
@@ -24,7 +24,8 @@
     "google-analytics",
     "@sanity/production-preview",
     "netlify-deploy-status-badge",
-    "seo-pane"
+    "seo-pane",
+    "media"
   ],
   "parts": [
     {


### PR DESCRIPTION
Installed the sanity [media browser](https://www.sanity.io/plugins/sanity-plugin-media) plugin to current studio project.

![image](https://user-images.githubusercontent.com/78787873/126950752-ca39dcaf-10a2-46ee-95f7-a3477d9c01f6.png)
![image](https://user-images.githubusercontent.com/78787873/126950847-b38e5999-08d2-4271-8e41-7e7a47c3f19b.png)
![image](https://user-images.githubusercontent.com/78787873/126950937-53090ef2-5fd6-4096-8b1f-5e10a361f0dc.png)
![image](https://user-images.githubusercontent.com/78787873/126951222-b2ec5fb2-b25e-422d-a60c-2533c88fb60c.png)
