### PR TITLE
Set default asset source to media browser plugin

### DIFF
--- a/sanity.json
+++ b/sanity.json
@@ -47,6 +47,10 @@
     {
       "implements": "part:@sanity/base/theme/variables/override-style",
       "path": "./src/brand/styles/variable.css"
+    },
+    {
+      "implements": "part:@sanity/form-builder/input/image/asset-sources",
+      "path": "./src/assetSources.js"
     }
   ],
   "env": {

--- a/src/assetSources.js
+++ b/src/assetSources.js
@@ -1,0 +1,3 @@
+import MediaAssetSource from 'part:sanity-plugin-media/asset-source'
+
+export default [MediaAssetSource]


### PR DESCRIPTION
Following changes in this [pull request](https://github.com/webriq-pagebuilder/studio-template-default/pull/37), set the default asset source to use this [media browser](https://www.sanity.io/plugins/sanity-plugin-media) plugin. 

To verify, when selecting images:
![image](https://user-images.githubusercontent.com/78787873/127320867-6837ddc9-dc75-4600-a76b-287fae29ead1.png)

the browser will now popup:
![image](https://user-images.githubusercontent.com/78787873/127320713-276ccbb3-191e-4f14-aabd-7e3418d70cf4.png)
