### PR TITLE
Remove netlify-deploy-status-badge

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "sanity-plugin-google-analytics": "^0.2.6",
     "sanity-plugin-json-input": "^0.1.0",
     "sanity-plugin-media": "^1.3.1",
-    "sanity-plugin-netlify-deploy-status-badge": "^0.0.3",
     "sanity-plugin-parts-list": "^1.0.2",
     "sanity-plugin-seo-pane": "^1.2.1",
     "sanity-plugin-tabs": "^2.0.1",

--- a/sanity.json
+++ b/sanity.json
@@ -27,8 +27,7 @@
     "dashboard-widget-document-list",
     "google-analytics",
     "@sanity/production-preview",
-    "seo-pane",
-    "netlify-deploy-status-badge"
+    "seo-pane"
   ],
   "parts": [
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1644,7 +1644,7 @@
   resolved "https://registry.npmjs.org/@sanity/icons/-/icons-1.1.7.tgz#f2b6f2d9b68965b6f26975c0d5528ae75e1472d8"
   integrity sha512-5KbAhNowjO94UjIrsaaKCGNLdHs+ek+RF5Bc+XRELOi1TFR0GBG3Wo7LK30df2ajA7TW6HwERLbPQB3sJyMRMQ==
 
-"@sanity/icons@^1.0.6", "@sanity/icons@^1.1.0", "@sanity/icons@^1.1.1", "@sanity/icons@^1.1.4", "@sanity/icons@^1.1.7", "@sanity/icons@^1.2.1":
+"@sanity/icons@^1.1.0", "@sanity/icons@^1.1.1", "@sanity/icons@^1.1.4", "@sanity/icons@^1.1.7", "@sanity/icons@^1.2.1":
   version "1.2.1"
   resolved "https://registry.npmjs.org/@sanity/icons/-/icons-1.2.1.tgz#0dcef7d0c0ea965acffbccb825d9da6ccaa53330"
   integrity sha512-dDXvyRIppU6OD8dNPBdd8LVBaIw5n5TrVOZ6AvT5pCoDswXlFQinoea5Fe4Huk26C+IZfe8d++P4tctnQPG8Vw==
@@ -1884,7 +1884,7 @@
     react "17.0.1"
     rxjs "^6.5.3"
 
-"@sanity/ui@0.33.29", "@sanity/ui@^0.33.19":
+"@sanity/ui@0.33.29":
   version "0.33.29"
   resolved "https://registry.npmjs.org/@sanity/ui/-/ui-0.33.29.tgz#263972f3a11c6063413764f23e3985b6e0e3657b"
   integrity sha512-9tu1Qz4Oh7AHUJiTa6hQAgxI5z0hzbqzfkUJXJsxyYKvZpCvStd3KbKBxUlaRzzDYGp9mmZ1icrz4NlIvG+51A==
@@ -9696,17 +9696,6 @@ sanity-plugin-media@^1.3.1:
     theme-ui "0.3.5"
     yup "0.32.8"
 
-sanity-plugin-netlify-deploy-status-badge@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/sanity-plugin-netlify-deploy-status-badge/-/sanity-plugin-netlify-deploy-status-badge-0.0.3.tgz#a948aed178198e8637480f506ad204a9a995e6ce"
-  integrity sha512-PLWEQAXAskg2C0+fZPe4eRA207yArgO8mj2TZawlLMXQQO9BqwWecJQeM5fvHTdhxrA0TlCDNzxZk3WAES+Byg==
-  dependencies:
-    "@sanity/icons" "^1.0.6"
-    "@sanity/ui" "^0.33.19"
-    date-fns "^2.21.3"
-    prop-types "15.7.2"
-    styled-components "^5.2.3"
-
 sanity-plugin-parts-list@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/sanity-plugin-parts-list/-/sanity-plugin-parts-list-1.0.2.tgz#9b964408f4ca0adf63b3c787297bef021fb09ddc"
@@ -10380,7 +10369,7 @@ style-value-types@4.1.4:
     hey-listen "^1.0.8"
     tslib "^2.1.0"
 
-styled-components@^5.2.0, styled-components@^5.2.1, styled-components@^5.2.3, styled-components@^5.3.0:
+styled-components@^5.2.0, styled-components@^5.2.1, styled-components@^5.3.0:
   version "5.3.1"
   resolved "https://registry.npmjs.org/styled-components/-/styled-components-5.3.1.tgz#8a86dcd31bff7049c2ed408bae36fa23f03f071a"
   integrity sha512-JThv2JRzyH0NOIURrk9iskdxMSAAtCfj/b2Sf1WJaCUsloQkblepy1jaCLX/bYE+mhYo3unmwVSI9I5d9ncSiQ==


### PR DESCRIPTION
The `netlify-deploy-badge` found on the sanity studio menu:

![image](https://user-images.githubusercontent.com/78787873/133102200-34334226-867b-4f47-ba06-5507d700cfc7.png)

Newer page builder sites will be deployed in Vercel (ref [PR #75](https://github.com/webriq-pagebuilder/app/pull/75) )so removing the desk tool plugin. 
