### PR TITLE
Issue-A0A6-I12 Publishing error in Blogs

### DIFF
--- a/src/documentActions/actions/createProductsPublishAction.js
+++ b/src/documentActions/actions/createProductsPublishAction.js
@@ -36,7 +36,7 @@ export default function createProductsPublishAction(props) {
       create();
   }, [isPublishing]);
 
-  if (type === "page") {
+  if (["page", "post", "category", "author"].includes(type)) {
     return {
       disabled: publish.disabled,
       label: isPublishing ? "Publishing…" : "Publish",


### PR DESCRIPTION
Reference issue link: [Publishing error in Blogs](https://crmplus.zoho.com/webriqgoesmad/index.do/cxapp/projects/webriqusa#buginfo/1512955000002969047/1512955000004737106)

On studio staging, the publish button is disabled on the post, author, and category document types even when changes are made. 

<img src="https://user-images.githubusercontent.com/78787873/158522418-05df8830-cff2-4897-8cdd-d1d191614cc7.png" width="400px" /> <img src="https://user-images.githubusercontent.com/78787873/158522425-36354b0d-dce6-490b-9023-374594e02668.png" width="400px"/>