### PR TITLE
validation and publish button always disabled fix

### DIFF
--- a/schemas/documents/pages.js
+++ b/schemas/documents/pages.js
@@ -15,7 +15,11 @@ export default {
         { id: fields._id }
       );
 
-      if (allSlug.includes(fields.slug.current)) {
+      let match = [];
+
+      allSlug.map((slug) => fields.slug.current === slug && match.push(slug));
+
+      if (match.length >= 2) {
         return "Slug is already in use in another page or post";
       }
 

--- a/src/badges/sectionBadge/index.js
+++ b/src/badges/sectionBadge/index.js
@@ -45,7 +45,7 @@ export function SectionBadge(props) {
   if (sections.includes(type)) {
     return {
       label: String(`${sectionName(type)} Section`).toUpperCase(),
-      title: `${sectionName(type)} Section`,
+      title: `${sectionName(type).toUpperCase()} SECTION`,
       color: "success",
     };
   }

--- a/src/documentActions/actions/createProductsPublishAction.js
+++ b/src/documentActions/actions/createProductsPublishAction.js
@@ -39,42 +39,26 @@ export default function createProductsPublishAction(props) {
 
   const isDisabled = markers.length !== 0 || publish?.disabled || isPublishing;
 
-  if (["page", "post", "category", "author"].includes(type)) {
-    return {
-      disabled: isDisabled,
-      label: (
-        <CustomPublishLabel
-          hasErrors={isDisabled}
-          isPublishing={isPublishing}
-        />
-      ),
-      onHandle: () => {
-        // This will update the button text
-        setIsPublishing(true);
+  return {
+    disabled: isDisabled || !draft,
+    label: ["page", "post", "category", "author"].includes(type) ? (
+      <CustomPublishLabel hasErrors={isDisabled} isPublishing={isPublishing} />
+    ) : isPublishing ? (
+      "Saving..."
+    ) : (
+      "Save"
+    ),
+    onHandle: () => {
+      // This will update the button text
+      setIsPublishing(true);
 
-        // Perform the publish
-        publish.execute();
+      // Perform the publish
+      publish.execute();
 
-        // Signal that the action is completed
-        props.onComplete();
-      },
-    };
-  } else {
-    return {
-      disabled: isDisabled || !draft?.label,
-      label: isPublishing ? "Saving..." : "Save",
-      onHandle: () => {
-        // This will update the button text
-        setIsPublishing(true);
-
-        // Perform the publish
-        publish.execute();
-
-        // Signal that the action is completed
-        props.onComplete();
-      },
-    };
-  }
+      // Signal that the action is completed
+      props.onComplete();
+    },
+  };
 }
 
 function CustomPublishLabel({ hasErrors = false, isPublishing = false }) {


### PR DESCRIPTION
- When a user edited a section, the publish button stays disabled until the validation is fix or satisfied.
- After a user finished editing section gave a custom label and save, the publish button will not be disabled
- The user can publish the page.

see here: https://www.loom.com/share/6056dd0a75384acdb516b2b8ada88638