### PR TITLE
C-Studio | Updates on when to display Store components

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,5 @@
+import sanityClient from "part:@sanity/base/client";
+
 // Site Netlify app used for web preview
 export const SANITY_STUDIO_PRODUCTION_NETLIFY_SITE_URL =
   process.env.SANITY_STUDIO_PRODUCTION_NETLIFY_SITE_URL;
@@ -24,3 +26,11 @@ export const SANITY_STUDIO_IN_CSTUDIO = process.env.SANITY_STUDIO_IN_CSTUDIO;
 export const SANITY_STUDIO_STORE_CORS_SECRET =
   process.env.SANITY_STUDIO_STORE_CORS_SECRET ||
   "cors_wE67XmOkBOgIXTmAs1iWJc5btQiCBosI";
+
+// Get current project dataset
+// https://www.sanity.io/docs/js-client#specifying-api-version
+const clientConfig = sanityClient.withConfig({
+  apiVersion: "2022-11-16", // use current UTC date - see "specifying API version"!
+}).clientConfig;
+
+export const SANITY_PROJECT_DATASET = clientConfig?.dataset;

--- a/src/deskStructure/index.js
+++ b/src/deskStructure/index.js
@@ -2,6 +2,10 @@ import S from "@sanity/desk-tool/structure-builder";
 import { sections } from "../badges/sectionBadge";
 import pages from "./pages";
 import store from "./store/";
+import { SANITY_STUDIO_IN_CSTUDIO, SANITY_PROJECT_DATASET } from "../config";
+
+const isProductionDataset = SANITY_PROJECT_DATASET === "production";
+const hidden = isProductionDataset && SANITY_STUDIO_IN_CSTUDIO === "false";
 
 const hiddenTypes = [
   "media.tag",
@@ -18,14 +22,19 @@ const hiddenTypes = [
   "searchPage",
   ...sections,
 ];
+
+const defaultListItems = [
+  pages,
+  ...S.documentTypeListItems().filter(
+    (listItem) => !hiddenTypes.includes(listItem.getId())
+  ),
+];
+
 export default () =>
   S.list()
     .title("Content")
-    .items([
-      pages,
-      S.divider(),
-      store,
-      ...S.documentTypeListItems().filter(
-        (listItem) => !hiddenTypes.includes(listItem.getId())
-      ),
-    ]);
+    .items(
+      hidden // Hide STORE on "production" dataset and C-Studio is disabled
+        ? defaultListItems
+        : [...defaultListItems, S.divider(), store] // Show STORE on "production" OR "staging" dataset and C-Studio is enabled
+    );

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,7 +1,7 @@
 /* 
   Call this functional component to update the existing schemas from included plugins with the changes from the custom folder
 */
-import { SANITY_STUDIO_IN_CSTUDIO } from "../config";
+import { SANITY_STUDIO_IN_CSTUDIO, SANITY_PROJECT_DATASET } from "../config";
 
 export const mergeReplaceAndAdd = (existingItems, newItems) => {
   const updatedItems = existingItems.map((existingItem) => {
@@ -21,7 +21,11 @@ export const mergeReplaceAndAdd = (existingItems, newItems) => {
       all = [...all, current];
     }
 
-    if (SANITY_STUDIO_IN_CSTUDIO === "false") {
+    // For "staging" dataset and if C-Studio is disabled, then C-Studio fields should be read-only
+    if (
+      SANITY_STUDIO_IN_CSTUDIO === "false" &&
+      SANITY_PROJECT_DATASET === "staging"
+    ) {
       return all?.map((items) => ({
         ...items,
         readOnly: true, // sets live editing of C-Studio schema documents to false


### PR DESCRIPTION
Zoho task: [C-Studio components in staging and production](https://crmplus.zoho.com/webriqgoesmad/index.do/cxapp/projects/webriqusa#taskdetail/1512955000002969047/1512955000004260328/1512955000006902254)

- C-Studio components in Sanity studio is read-only on staging if C-Studio is disabled
- C-Studio components in Sanity studio is hidden on production if C-Studio is disabled
- Otherwise, for both datasets if C-Studio is **enabled** then show STORE components
