### PR TITLE
Merge changes from feat/cstudio branch to PR#96

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@sanity/vision": "^2.35.2",
     "@webriq-pagebuilder/sanity-plugin-input-component-conditional-fields": "^1.0.0",
     "@webriq-pagebuilder/sanity-plugin-schema-blog": "^1.0.6",
-    "@webriq-pagebuilder/sanity-plugin-schema-commerce": "1.0.17-feat-cstudio.1",
+    "@webriq-pagebuilder/sanity-plugin-schema-commerce": "1.0.17-feat-cstudio.2",
     "@webriq-pagebuilder/sanity-plugin-schema-default": "^1.0.22",
     "@webriq-pagebuilder/sanity-plugin-webriq-blog": "^1.0.6",
     "@webriq-pagebuilder/sanity-plugin-webriq-forms": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@sanity/vision": "^2.35.2",
     "@webriq-pagebuilder/sanity-plugin-input-component-conditional-fields": "^1.0.0",
     "@webriq-pagebuilder/sanity-plugin-schema-blog": "^1.0.6",
-    "@webriq-pagebuilder/sanity-plugin-schema-commerce": "^1.0.17-cstudio.4",
+    "@webriq-pagebuilder/sanity-plugin-schema-commerce": "^1.0.17-feat-cstudio.0",
     "@webriq-pagebuilder/sanity-plugin-schema-default": "^1.0.22",
     "@webriq-pagebuilder/sanity-plugin-webriq-blog": "^1.0.6",
     "@webriq-pagebuilder/sanity-plugin-webriq-forms": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@sanity/vision": "^2.35.2",
     "@webriq-pagebuilder/sanity-plugin-input-component-conditional-fields": "^1.0.0",
     "@webriq-pagebuilder/sanity-plugin-schema-blog": "^1.0.6",
-    "@webriq-pagebuilder/sanity-plugin-schema-commerce": "1.0.17-feat-cstudio.2",
+    "@webriq-pagebuilder/sanity-plugin-schema-commerce": "1.0.17-feat-cstudio.3",
     "@webriq-pagebuilder/sanity-plugin-schema-default": "^1.0.22",
     "@webriq-pagebuilder/sanity-plugin-webriq-blog": "^1.0.6",
     "@webriq-pagebuilder/sanity-plugin-webriq-forms": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@sanity/vision": "^2.35.2",
     "@webriq-pagebuilder/sanity-plugin-input-component-conditional-fields": "^1.0.0",
     "@webriq-pagebuilder/sanity-plugin-schema-blog": "^1.0.6",
-    "@webriq-pagebuilder/sanity-plugin-schema-commerce": "^1.0.17-feat-cstudio.0",
+    "@webriq-pagebuilder/sanity-plugin-schema-commerce": "1.0.17-feat-cstudio.1",
     "@webriq-pagebuilder/sanity-plugin-schema-default": "^1.0.22",
     "@webriq-pagebuilder/sanity-plugin-webriq-blog": "^1.0.6",
     "@webriq-pagebuilder/sanity-plugin-webriq-forms": "^1.0.7",

--- a/schemas/documents/pages.js
+++ b/schemas/documents/pages.js
@@ -97,12 +97,6 @@ export default {
           to: [{ type: "pricing" }],
         },
         {
-          title: "All Products",
-          name: "allProducts",
-          type: "reference",
-          to: [{ type: "allProducts" }],
-        },
-        {
           title: "Product Info",
           name: "productInfo",
           type: "reference",

--- a/src/brand/styles/variable.css
+++ b/src/brand/styles/variable.css
@@ -178,3 +178,13 @@ button#presence-menu,
 button#login-status-menu {
   display: none !important;
 }
+
+/* Desktop: when using field groups, we hide the first tab */
+[data-ui="TabList"][data-testid="field-group-tabs"] > div:first-child {
+  display: none;
+}
+
+/* Mobile: when using field groups, hide the first option */
+select[data-testid="field-group-select"] > option:first-child {
+  display: none;
+}

--- a/src/deskStructure/index.js
+++ b/src/deskStructure/index.js
@@ -20,6 +20,8 @@ const hiddenTypes = [
   "cartPage",
   "wishlistPage",
   "searchPage",
+  "slotProductInfo",
+  "slotCollectionInfo",
   ...sections,
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2486,14 +2486,15 @@
     "@sanity/desk-tool" "^2.17.2"
     react-icons "^4.2.0"
 
-"@webriq-pagebuilder/sanity-plugin-schema-commerce@^1.0.17-cstudio.4":
-  version "1.0.17-cstudio.4"
-  resolved "https://registry.yarnpkg.com/@webriq-pagebuilder/sanity-plugin-schema-commerce/-/sanity-plugin-schema-commerce-1.0.17-cstudio.4.tgz#5d92dd254ff2e3eff940707f2b3b6119f1564c8c"
-  integrity sha512-S0z8FIXSDgdibAhBrKO6agDXbP0glBdkIxZUitVwnOOHiT7pLlL2FLzDqtNjUcxJdvqW0KpylYwru4Q1Gx4w6Q==
+"@webriq-pagebuilder/sanity-plugin-schema-commerce@^1.0.17-feat-cstudio.0":
+  version "1.0.17-feat-cstudio.0"
+  resolved "https://registry.yarnpkg.com/@webriq-pagebuilder/sanity-plugin-schema-commerce/-/sanity-plugin-schema-commerce-1.0.17-feat-cstudio.0.tgz#ef313daa4e8d0be523539c6852328b9e5174cbb6"
+  integrity sha512-TTKn431fb4ITaPVYltzGHce5XwIO56VdZWu2pJUiE7LHtXgV2pNPHN9RugHA4ZVOeEJgQmAQda8c1xUSxxaLzg==
   dependencies:
     "@sanity/base" "^2.35.2"
     "@sanity/form-builder" "^2.35.2"
     "@sanity/ui" "^0.37.22"
+    "@webriq-pagebuilder/sanity-plugin-input-component-variants" "^0.0.4"
     "@webriq-pagebuilder/sanity-plugin-schema-default" "^1.0.23-cstudio.0"
     nanoid "^3.1.30"
     react-icons "^4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2486,10 +2486,10 @@
     "@sanity/desk-tool" "^2.17.2"
     react-icons "^4.2.0"
 
-"@webriq-pagebuilder/sanity-plugin-schema-commerce@^1.0.17-feat-cstudio.0":
-  version "1.0.17-feat-cstudio.0"
-  resolved "https://registry.yarnpkg.com/@webriq-pagebuilder/sanity-plugin-schema-commerce/-/sanity-plugin-schema-commerce-1.0.17-feat-cstudio.0.tgz#ef313daa4e8d0be523539c6852328b9e5174cbb6"
-  integrity sha512-TTKn431fb4ITaPVYltzGHce5XwIO56VdZWu2pJUiE7LHtXgV2pNPHN9RugHA4ZVOeEJgQmAQda8c1xUSxxaLzg==
+"@webriq-pagebuilder/sanity-plugin-schema-commerce@1.0.17-feat-cstudio.1":
+  version "1.0.17-feat-cstudio.1"
+  resolved "https://registry.yarnpkg.com/@webriq-pagebuilder/sanity-plugin-schema-commerce/-/sanity-plugin-schema-commerce-1.0.17-feat-cstudio.1.tgz#55c859b5e04ed6b61c6b209ac4813d1e71915b46"
+  integrity sha512-6re5pHgoVWTGuXjku3Nmp55Fk8gvkAXoHBOgwdxnKfC1pnxJiuEBTt776ak8E8YdmZsBYVkj6vOsIVBGWB3FGg==
   dependencies:
     "@sanity/base" "^2.35.2"
     "@sanity/form-builder" "^2.35.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2486,10 +2486,10 @@
     "@sanity/desk-tool" "^2.17.2"
     react-icons "^4.2.0"
 
-"@webriq-pagebuilder/sanity-plugin-schema-commerce@1.0.17-feat-cstudio.2":
-  version "1.0.17-feat-cstudio.2"
-  resolved "https://registry.yarnpkg.com/@webriq-pagebuilder/sanity-plugin-schema-commerce/-/sanity-plugin-schema-commerce-1.0.17-feat-cstudio.2.tgz#610d2d78886dc9a494b926ca7c846437266931db"
-  integrity sha512-eW5OQLrbKWQOTVCNWw0sd0B0cZl5pUBNW8eFAWDA1IKidTOvVN17VJ1nr8/aXXEcDtwQ7DozS+ErNHHyFpt3uw==
+"@webriq-pagebuilder/sanity-plugin-schema-commerce@1.0.17-feat-cstudio.3":
+  version "1.0.17-feat-cstudio.3"
+  resolved "https://registry.yarnpkg.com/@webriq-pagebuilder/sanity-plugin-schema-commerce/-/sanity-plugin-schema-commerce-1.0.17-feat-cstudio.3.tgz#f98865cee875e93908d7d6c94e1fbb2f4ec7576c"
+  integrity sha512-cSsUFu/56edZI6ftj7ItPkBCf1+0uKkLT6KEjSJpz3zB9dT5iMqj/koGeFHWhQkshKuVPhObC3DmLgxLp3KI7g==
   dependencies:
     "@sanity/base" "^2.35.2"
     "@sanity/form-builder" "^2.35.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2486,10 +2486,10 @@
     "@sanity/desk-tool" "^2.17.2"
     react-icons "^4.2.0"
 
-"@webriq-pagebuilder/sanity-plugin-schema-commerce@1.0.17-feat-cstudio.1":
-  version "1.0.17-feat-cstudio.1"
-  resolved "https://registry.yarnpkg.com/@webriq-pagebuilder/sanity-plugin-schema-commerce/-/sanity-plugin-schema-commerce-1.0.17-feat-cstudio.1.tgz#55c859b5e04ed6b61c6b209ac4813d1e71915b46"
-  integrity sha512-6re5pHgoVWTGuXjku3Nmp55Fk8gvkAXoHBOgwdxnKfC1pnxJiuEBTt776ak8E8YdmZsBYVkj6vOsIVBGWB3FGg==
+"@webriq-pagebuilder/sanity-plugin-schema-commerce@1.0.17-feat-cstudio.2":
+  version "1.0.17-feat-cstudio.2"
+  resolved "https://registry.yarnpkg.com/@webriq-pagebuilder/sanity-plugin-schema-commerce/-/sanity-plugin-schema-commerce-1.0.17-feat-cstudio.2.tgz#610d2d78886dc9a494b926ca7c846437266931db"
+  integrity sha512-eW5OQLrbKWQOTVCNWw0sd0B0cZl5pUBNW8eFAWDA1IKidTOvVN17VJ1nr8/aXXEcDtwQ7DozS+ErNHHyFpt3uw==
   dependencies:
     "@sanity/base" "^2.35.2"
     "@sanity/form-builder" "^2.35.2"


### PR DESCRIPTION
[@feat/cstudio](https://github.com/webriq-pagebuilder/sanity-packages/commits/feat/cstudio) branch changes from sanity-plugin-schema-commerce:

1. Added `slotProductInfo` and `slotCollectionInfo` sections (read only when added as initial values to the Design tab of new Product and Collections page respectively)
2. Implemented `field groups` to Product page (**_Store > Products_**) where the productInfo section now is part of the page (removed as section) and the Design tab uses the slotProductInfo in item 1.
3. Implemented `field groups` to Collections page (**_Store > Collections_**) where the it now has the products array to add product pages that belong to collection and the Design tab that uses the slotCollectionInfo in item 1.
4. Updated the schema for `allProducts` section where it will now reference **_Store > Collections_** pages
