### PR TITLE
Inline Editing Action Button

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,16 +1,16 @@
 import { defineConfig } from "sanity"
 import {
-  SANITY_STUDIO_PROJECT_NAME,
-  SANITY_STUDIO_DATASET,
   SANITY_STUDIO_API_PROJECT_ID,
-  SANITY_STUDIO_OPENAI_KEY
+  SANITY_STUDIO_DATASET,
+  SANITY_STUDIO_OPENAI_KEY,
+  SANITY_STUDIO_PROJECT_NAME,
 } from "./src/config"
 
 // desk customization
-import deskStructure from "./src/deskStructure"
+import "./global.css"
 import { Logo } from "./src/brand/logo"
 import { DefaultStudioTheme } from "./src/brand/theme"
-import "./global.css"
+import deskStructure from "./src/deskStructure"
 
 // document badge and action
 import { LiveURLBadge } from "./src/badges/LiveURLBadge"
@@ -20,37 +20,37 @@ import { ResolveDocumentActions } from "./src/documentActions"
 import { schemaTypes } from "./schemas/schema"
 
 // plugins
-import { media } from "sanity-plugin-media"
 import { codeInput } from "@sanity/code-input"
+import { media } from "sanity-plugin-media"
 
-import { openaiImageAsset } from "sanity-plugin-asset-source-openai"
 import { visionTool } from "@sanity/vision"
+import { webriqGPT3 } from "@webriq-pagebuilder/sanity-plugin-input-component-gpt3"
 import { webriqBlog } from "@webriq-pagebuilder/sanity-plugin-webriq-blog"
+import { webriqComponents } from "@webriq-pagebuilder/sanity-plugin-webriq-components"
 import { webriqForms } from "@webriq-pagebuilder/sanity-plugin-webriq-forms"
 import { webriqPayments } from "@webriq-pagebuilder/sanity-plugin-webriq-payments"
-import { webriqGPT3 } from "@webriq-pagebuilder/sanity-plugin-input-component-gpt3"
-import { webriqComponents } from "@webriq-pagebuilder/sanity-plugin-webriq-components"
+import { openaiImageAsset } from "sanity-plugin-asset-source-openai"
 
 // Open preview
-import resolveProductionUrl from "./src/resolvePreviewUrl"
+import InlineEditBtn from "./src/inspector/InlineEditBtn"
 
 export default defineConfig({
   title: SANITY_STUDIO_PROJECT_NAME,
   projectId: SANITY_STUDIO_API_PROJECT_ID,
   dataset: SANITY_STUDIO_DATASET,
   plugins: [
-    deskStructure, 
+    deskStructure,
     webriqComponents(),
-    visionTool(), 
-    webriqForms(), 
-    webriqPayments(), 
+    visionTool(),
+    webriqForms(),
+    webriqPayments(),
     webriqBlog(),
     webriqGPT3(),
     media(),
     codeInput(),
     openaiImageAsset({
-      API_KEY: SANITY_STUDIO_OPENAI_KEY // TODO: Update personal API key with default from WebriQ
-    })
+      API_KEY: SANITY_STUDIO_OPENAI_KEY, // TODO: Update personal API key with default from WebriQ
+    }),
   ],
   tools: (prev) => {
     // 👇 Uses environment variables set by Vite in development mode
@@ -69,7 +69,7 @@ export default defineConfig({
     image: {
       assetSources: (prev) => {
         // only display media browser and openai image assets as default options
-        return prev.filter((asset) => asset.name !== "sanity-default") 
+        return prev.filter((asset) => asset.name !== "sanity-default")
       },
     },
   },
@@ -78,14 +78,25 @@ export default defineConfig({
   },
   document: {
     badges: [LiveURLBadge],
-    actions: (prev, context) =>
-      ResolveDocumentActions({ prev, context }),
+    actions: (prev, context) => ResolveDocumentActions({ prev, context }),
     // Open preview link
     productionUrl: async (prev, context) => {
       // context includes the client and other details
       const { document } = context
 
-      return resolveProductionUrl(document)
-    }
+      // write to localStorage our current document
+      if (typeof window) {
+        window.localStorage.setItem("currentDocument", JSON.stringify(document))
+      }
+
+      return prev
+    },
+    inspectors: (prev, ...rest) => {
+      if (rest?.[0]?.documentType === "page") {
+        return [InlineEditBtn, ...prev]
+      }
+
+      return prev
+    },
   },
 })

--- a/src/inspector/InlineEditBtn.tsx
+++ b/src/inspector/InlineEditBtn.tsx
@@ -1,0 +1,15 @@
+import { ArrowTopRightIcon } from "@sanity/icons"
+import { lazy } from "react"
+import { DocumentInspector } from "sanity"
+
+const InlineEditBtn: DocumentInspector = {
+  name: "InlineEditBtn",
+  useMenuItem: () => ({
+    icon: ArrowTopRightIcon,
+    title: "Launch LIVE Edit",
+    showAsAction: true,
+  }),
+  component: lazy(() => import("./LaunchPreview")),
+}
+
+export default InlineEditBtn

--- a/src/inspector/InlineEditBtn.tsx
+++ b/src/inspector/InlineEditBtn.tsx
@@ -1,12 +1,13 @@
-import { ArrowTopRightIcon } from "@sanity/icons"
+import { FiExternalLink } from "react-icons/fi"
+
 import { lazy } from "react"
 import { DocumentInspector } from "sanity"
 
 const InlineEditBtn: DocumentInspector = {
   name: "InlineEditBtn",
   useMenuItem: () => ({
-    icon: ArrowTopRightIcon,
-    title: "Launch LIVE Edit",
+    icon: FiExternalLink,
+    title: "Launch Inline Editing",
     showAsAction: true,
   }),
   component: lazy(() => import("./LaunchPreview")),

--- a/src/inspector/LaunchPreview.tsx
+++ b/src/inspector/LaunchPreview.tsx
@@ -42,7 +42,7 @@ export default function LaunchPreview(props: DocumentInspectorProps) {
           <Text size={2} weight="bold">
             Inline Editing Launched 🚀
           </Text>
-          <Text size={1}>(This will automatically close in {countdown} seconds)</Text>
+          <Text size={1}>(This pane will automatically close in {countdown} seconds)</Text>
         </Stack>
       </Card>
     </Flex>

--- a/src/inspector/LaunchPreview.tsx
+++ b/src/inspector/LaunchPreview.tsx
@@ -1,0 +1,50 @@
+import { Box, Card, Flex, Stack, Text } from "@sanity/ui"
+import React from "react"
+import { DocumentInspectorProps } from "sanity"
+import resolveProductionUrl from "../resolvePreviewUrl"
+
+export default function LaunchPreview(props: DocumentInspectorProps) {
+  const { onClose } = props
+  const [countdown, setCountdown] = React.useState(5)
+
+  React.useEffect(() => {
+    try {
+      if (typeof window) {
+        const doc = window.localStorage.getItem("currentDocument")
+        const document = JSON.parse(doc)
+
+        window.open(resolveProductionUrl(document), "_blank")
+      }
+    } catch (err) {}
+
+    const timer = setInterval(() => {
+      setCountdown((prevCountdown) => prevCountdown - 1)
+
+      if (countdown === 3) {
+        clearInterval(timer)
+      }
+    }, 1000)
+
+    setTimeout(() => {
+      clearInterval(timer)
+      onClose()
+    }, 5000)
+
+    return () => {
+      clearInterval(timer)
+    }
+  }, [])
+
+  return (
+    <Flex direction="column" height="fill" overflow="hidden">
+      <Card flex={1} overflow="auto" padding={4}>
+        <Stack space={4}>
+          <Text size={2} weight="bold">
+            Inline Editing Launched 🚀
+          </Text>
+          <Text size={1}>(This will automatically close in {countdown} seconds)</Text>
+        </Stack>
+      </Card>
+    </Flex>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2603,11 +2603,6 @@ acorn@^8.1.0, acorn@^8.8.1, acorn@^8.9.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
   integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
 
-add@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/add/-/add-2.0.6.tgz#248f0a9f6e5a528ef2295dbeec30532130ae2235"
-  integrity sha512-j5QzrmsokwWWp6kUcJQySpbG+xfOBqqKnup3OIk1pz+kB/80SLorZ9V8zHFLO92Lcd+hbvq8bT+zOGoPkmBV0Q==
-
 agent-base@6:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -7006,11 +7001,6 @@ yargs@^17.3.0:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
-
-yarn@^1.22.19:
-  version "1.22.19"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.19.tgz#4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
-  integrity sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This moves the **Open Preview** to its own action button labeled **Launch Inline Editing** that is visible and easily accessible. The new implementation launches the same link in a new tab but also briefly opens the Inspector pane in a while for 5 seconds as it automatically closes after that.

### Old

<img width="390" alt="CleanShot 2023-08-31 at 16 31 04@2x" src="https://github.com/webriq-pagebuilder/studio-template-default/assets/6467262/d8c72988-afec-4770-a7de-6afc2a6f039e">

---

### New


##### Action Button

<img width="196" alt="CleanShot 2023-08-31 at 16 33 46@2x" src="https://github.com/webriq-pagebuilder/studio-template-default/assets/6467262/96901ab8-e2c9-4f20-9b78-55a47299dc91">

##### Inspector Panel Opened

<img width="377" alt="CleanShot 2023-08-31 at 16 33 06@2x" src="https://github.com/webriq-pagebuilder/studio-template-default/assets/6467262/3b7a9b7b-c726-4537-aadb-4084bbb755fa">

