### PR TITLE
Studio Versioning

### DIFF
--- a/src/deskStructure/StudioDocs.tsx
+++ b/src/deskStructure/StudioDocs.tsx
@@ -1,18 +1,38 @@
+import { Box, Flex, Stack, Text } from "@sanity/ui"
+import packageJson from "../../package.json"
+import { GoLinkExternal } from "react-icons/go"
+
 const CANVA_WSTUDIO_PRESENTATION =
   process.env.NEXT_PUBLIC_CANVA_WSTUDIO_PRESENTATION ||
-  "https://www.canva.com/design/DAFGKT1MdX4/view?embed#20";
+  "https://www.canva.com/design/DAFGKT1MdX4/view?embed#20"
 
 export const StudioDocs = () => {
   return (
-    <iframe
-      src={CANVA_WSTUDIO_PRESENTATION}
-      style={{
-        display: "block",
-        width: "100%",
-        height: "100%",
-      }}
-      frameBorder={0}
-      allowFullScreen={true}
-    ></iframe>
-  );
-};
+    <>
+      <Stack padding={4} space={2}>
+        <Text size={2}>
+          WebriQ Studio Version: <strong>{packageJson.version}</strong>
+        </Text>
+        <a
+          href={`https://github.com/webriq-pagebuilder/studio-template-default/releases/tag/${packageJson.version}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ display: "flex", alignItems: "center", gap: 5 }}
+        >
+          View Changelog <GoLinkExternal />
+        </a>
+      </Stack>
+
+      <iframe
+        src={CANVA_WSTUDIO_PRESENTATION}
+        style={{
+          display: "block",
+          width: "100%",
+          height: "100%",
+        }}
+        frameBorder={0}
+        allowFullScreen={true}
+      ></iframe>
+    </>
+  )
+}

--- a/src/deskStructure/index.ts
+++ b/src/deskStructure/index.ts
@@ -2,9 +2,9 @@ import { deskTool as sanityDesktool } from "sanity/desk"
 
 import { Page } from "./pages"
 import { Store } from "./store"
-import { StudioDocs } from "./StudioDocs";
+import { StudioDocs } from "./StudioDocs"
 
-import { HelpCircleIcon } from "@sanity/icons";
+import { HelpCircleIcon } from "@sanity/icons"
 
 export default sanityDesktool({
   structure: (S) =>
@@ -19,7 +19,7 @@ export default sanityDesktool({
         S.listItem()
           .title("Guide")
           .icon(HelpCircleIcon)
-          .child(S.component(StudioDocs).title("Help Guide")),
+          .child(S.component(StudioDocs).title("Help Guide & Version")),
       ]),
   name: "desk",
   title: "Desk",


### PR DESCRIPTION
This adds a little component in the **Help Guide** that shows the **_current version of the Studio_**. You can also click on the link to learn more about the changelog (changes between current version vs prior version).

<img width="1415" alt="CleanShot 2023-08-31 at 16 39 06@2x" src="https://github.com/webriq-pagebuilder/studio-template-default/assets/6467262/839358fd-addd-4eac-8cdf-3cbe5edff394">
